### PR TITLE
Fixed typos and suggested changes to documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,9 @@
 
 .. image:: https://raw.github.com/amol-/depot/master/docs/_static/logo.png
 
-depot
-=====
+DEPOT - File Storage Made Easy
+==============================
 
-DEPOT is a toolkit for storing files and attachments in web applications
+DEPOT is a framework for easily storing and serving files in
+web applications on Python2.6+ and Python3.2+.
 

--- a/depot/io/gridfs.py
+++ b/depot/io/gridfs.py
@@ -54,7 +54,7 @@ class GridFSStoredFile(StoredFile):
 class GridFSStorage(FileStorage):
     """:class:`depot.io.interfaces.FileStorage` implementation that stores files on MongoDB.
 
-    All the files are stored using GridFS to the database pointed by the ``mongouri`` into
+    All the files are stored using GridFS to the database pointed by the ``mongouri`` parameter into
     the collection named ``collection``.
 
     """

--- a/depot/io/interfaces.py
+++ b/depot/io/interfaces.py
@@ -22,7 +22,7 @@ class StoredFile(IOBase):
         - last_modified
         - content_length
 
-    Already stored files can only be read back, so they are require to only provide
+    Already stored files can only be read back, so they are required to only provide
     ``read(self, n=-1)``, ``close()`` methods and ``closed`` property so that they
     can be read.
 
@@ -64,7 +64,7 @@ class StoredFile(IOBase):
         """This is the filename of the saved file
 
         If a filename was not available when the file was created
-        this will return "unkwnown" as filename.
+        this will return "unknown" as filename.
         """
         return self.filename
 

--- a/depot/io/local.py
+++ b/depot/io/local.py
@@ -67,7 +67,7 @@ class LocalStoredFile(StoredFile):
 class LocalFileStorage(FileStorage):
     """:class:`depot.io.interfaces.FileStorage` implementation that stores files locally.
 
-    All the files are stored inside a directory specified by ``storage_path`` parameter.
+    All the files are stored inside a directory specified by the ``storage_path`` parameter.
 
     """
     def __init__(self, storage_path):

--- a/docs/database.rst
+++ b/docs/database.rst
@@ -8,7 +8,7 @@ to a model field.
 Attaching to Models
 ------------------------------
 
-Attaching files to models is as simple as declaring a field of the model itself,
+Attaching files to models is as simple as declaring a field on the model itself,
 support is currently provided for **SQLAlchemy** through the
 :class:`depot.fields.sqlalchemy.UploadedFileField` and for **Ming (MongoDB)** through
 the :class:`depot.fields.ming.UploadedFileProperty`::
@@ -48,7 +48,7 @@ This is the same object you will get back when reloading the models from databas
 apart from the file itself which is accessible through the ``.file`` property, it provides
 additional attributes described into the :class:`.UploadedFile` documentation itself.
 
-Most important property is probably ``.url`` property which provides an URL where the
+Most important property is probably the ``.url`` property which provides an URL where the
 file can be accessed in case the storage supports HTTP or the :class:`.DepotMiddleware` is
 available in your WSGI application.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,13 +1,13 @@
-DEPOT - File Storage made Easy
-=========================================
+DEPOT - File Storage Made Easy
+==============================
 
-Welcome to DEPOT Documentation, DEPOT is an framework
-for easily storing and serving files in web applications on
-Python2.6+ and Python3.2+
+Welcome to the DEPOT Documentation.
+DEPOT is a framework for easily storing and serving files in
+web applications on Python2.6+ and Python3.2+.
 
 Depot can be used :ref:`Standalone <depot_standalone>` or
-:ref:`With your ORM <depot_with_your_orm>` to quickly provide
-attachments support to your models.
+:ref:`with your ORM <depot_with_your_orm>` to quickly provide
+attachment support to your model.
 
 Modern web applications need to rely on a huge amount of
 stored images, generated files and other data which is usually
@@ -20,11 +20,12 @@ like you would for plain data.
 Depot is a swiss army knife for files that provides:
 
     - Multiple backends: Store your data on GridFS or S3 with a *single API*
-    - Meant for *Evolution*: Change backend when you want, old data will continue to work
-    - Integrates with your *ORM*: When using SQLAlchemy attachments are handled like a
-      plain model attribute. It's also *session ready* rollback causes the files to be deleted.
+    - Meant for *Evolution*: Change the backend anytime you want, old data will continue to work
+    - Integrates with your *ORM*: When using SQLAlchemy, attachments are handled like a
+      plain model attribute. It's also *session ready*: Rollback causes the files to be deleted.
     - Smart *File Serving*: When the backend already provides a public HTTP endpoint (like S3)
-      the WSGI :class:`depot.middleware.DepotMiddleware` will serve it instead of loading the files.
+      the WSGI :class:`depot.middleware.DepotMiddleware` will redirect to the public address
+      instead of loading and serving the files by itself.
     - Flexible: The :class:`depot.manager.DepotManager` will handle configuration,
       middleware creation and files for your application, but if you want you can manually
       create multiple depots or middlewares without using the manager.
@@ -35,11 +36,11 @@ Depot is a swiss army knife for files that provides:
 Depot Standalone
 -------------------------
 
-Depot can easily be used to save and retrieve files in any python script,
+Depot can easily be used to save and retrieve files in any Python script,
 Just get a depot using the :class:`depot.manager.DepotManager` and store the files.
-With each file, additional data commonly used in HTTP is stored like *last_modified*,
-*content_type* and so on. This data is available inside the :class:`depot.io.interfaces.StoredFile`
-which is returned when getting the file back:
+With each file, additional data commonly used in HTTP like *last_modified*,
+*content_type* and so on is stored. This data is available inside the
+:class:`depot.io.interfaces.StoredFile` which is returned when getting the file back:
 
 .. code-block:: python
 
@@ -67,8 +68,9 @@ which is returned when getting the file back:
 Attaching Files to Models
 --------------------------
 
-Depot also provides simple integration with SQLAlchemy for storing files attached
-to your ORM document. Just declare them inside your models and assign the files:
+Depot also features simple integration with SQLAlchemy by providing customized
+model field types for storing files attached to your ORM document.
+Just declare columns with these types inside your models and assign the files:
 
 .. code-block:: python
 

--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -24,7 +24,7 @@ storages through the ``.backend`` option. To store data on GridFS you would use:
         'depot.mongouri': 'mongodb://localhost/db'
     })
 
-every other option apart the ``.backend`` one will be passed to the storage as
+Every other option apart the ``.backend`` one will be passed to the storage as
 a constructor argument. You can even use your own storage by setting the full python
 path of the class you want to use.
 
@@ -53,7 +53,7 @@ Saving and Retrieving Files
 ------------------------------
 
 Once you have a working storage, saving files is as easy as calling the :meth:`.FileStorage.create`
-method passing the file (or the ``bytes``) you want to store::
+method passing the file (or the ``bytes`` object) you want to store::
 
     depot = DepotManager.get()
     fileid = depot.create(open('/tmp/file.png'))
@@ -71,8 +71,9 @@ Getting the file back can be done using :meth:`.FileStorage.get` from the storag
 
     stored_file = depot.get(fileid)
 
-Getting back the file will only retrieve the file metadata and will return an :class:`.StoredFile`
-object, if you actually want to read the file content you should then call the ``read`` method::
+Getting back the file will only retrieve the file metadata and will return a :class:`.StoredFile`
+object. This object can be used like a normal Python ``file`` object,
+so if you actually want to read the file content you should then call the ``read`` method::
 
     stored_file.content_type  # This will be 'image/png'
     image = stored_file.read()
@@ -106,20 +107,20 @@ available.
 Depot for the Web
 =============================
 
-Files Metadata
+File Metadata
 ------------------------------
 
 As Depot has been explicitly designed for web applications development, it will provide
-all the file metadata which is required for HTTP Headers when serving files or which is common
+all the file metadata which is required for HTTP headers when serving files or which are common
 in the web world.
 
 This is provided by the :class:`.StoredFile` you retrieve from the file storage and includes:
 
-    * filename -> Original name of the file, if you need to serve it to the user for download.
-    * content_type -> File content type, for the response content type when serving file back
+    * ``filename`` -> Original name of the file, if you need to serve it to the user for download.
+    * ``content_type`` -> File content type, for the response content type when serving file back
       the file to the browser.
-    * last_modified -> Can be used to implement caching and last modified header in HTTP.
-    * content_length -> Size of the file, is usually the content length of the HTTP response when
+    * ``last_modified`` -> Can be used to implement caching and last modified header in HTTP.
+    * ``content_length`` -> Size of the file, is usually the content length of the HTTP response when
       serving the file back.
 
 Serving Files on HTTP
@@ -131,7 +132,7 @@ provided by :class:`.StoredFile.public_url`. In case the ``public_url`` is ``Non
 that the storage doesn't provide HTTP access directly.
 
 In such case files can be served using a :class:`.DepotMiddleware` WSGI middleware. The
-DepotMiddlware supports serving files from any backend, support ETag caching and in case of
+DepotMiddlware supports serving files from any backend, supports ETag caching and in case of
 storages directly supporting HTTP it will just redirect the user to the storage itself.
 
 Unless you need to achieve maximum performances it is usually a good approach to just use
@@ -140,12 +141,12 @@ the WSGI Middleware and let it serve all your files for you::
     app = DepotManager.make_middleware(app)
 
 By default the Depot middleware will serve the files at the ``/depot`` URL using their path
-(same passed to the :meth:`.DepotManager.get_file` method). So in case you need to retrieve
+(the same as passed to the :meth:`.DepotManager.get_file` method). So in case you need to retrieve
 a file with id **3774a1a0-0879-11e4-b658-0800277ee230** stored into **my_gridfs** depot the
 URL will be ``/depot/my_gridfs/3774a1a0-0879-11e4-b658-0800277ee230``.
 
-Changing base URL and caching can be done through the :meth:`.DepotManager.make_middleware`
-options, any option passed to ``make_middlware`` will be forwarded to :class:`.DepotMiddleware`.
+Changing the base URL and caching can be done through the :meth:`.DepotManager.make_middleware`
+options, any option passed to ``make_middleware`` will be forwarded to :class:`.DepotMiddleware`.
 
 
 Handling Multiple Storages


### PR DESCRIPTION
And some random remarks:
- You could maybe reference tgext.datahelpers and the Django FileField/Storage which are a bit similar at least for local storage
- You could use the "Interactive Interpreter" doc style, where you display the output of the print statements and so on
- Some Sphinx `:class:`-Links are not rendered correctly as links
- Justified text doesn't look so good on the API doc page
