### PR TITLE
Add list method to retrieve a list of fileids from all available storages

### DIFF
--- a/depot/io/awss3.py
+++ b/depot/io/awss3.py
@@ -158,6 +158,9 @@ class S3Storage(FileStorage):
         k = self._bucket.get_key(fileid)
         return k is not None
 
+    def list(self):
+        return [key.name for key in self._bucket.list()]
+
 
 def _check_file_id(file_id):
     # Check that the given file id is valid, this also

--- a/depot/io/gridfs.py
+++ b/depot/io/gridfs.py
@@ -108,6 +108,11 @@ class GridFSStorage(FileStorage):
         fileid = _check_file_id(fileid)
         return self._gridfs.exists(fileid)
 
+    def list(self):
+        list_ids = []
+        for filename in self._gridfs.list():
+            list_ids.append(self._gridfs.find_one({"filename": filename})._id)
+        return list_ids
 
 def _check_file_id(file_id):
     # Check that the given file id is valid, this also

--- a/depot/io/gridfs.py
+++ b/depot/io/gridfs.py
@@ -111,7 +111,7 @@ class GridFSStorage(FileStorage):
     def list(self):
         list_ids = []
         for filename in self._gridfs.list():
-            list_ids.append(self._gridfs.find_one({"filename": filename})._id)
+            list_ids.append(str(self._gridfs.find_one({"filename": filename})._id))
         return list_ids
 
 def _check_file_id(file_id):

--- a/depot/io/interfaces.py
+++ b/depot/io/interfaces.py
@@ -209,3 +209,8 @@ class FileStorage(with_metaclass(ABCMeta, object)):
     def exists(self, file_or_id):  # pragma: no cover
         """Returns if a file or its ID still exist."""
         return
+
+    @abstractmethod
+    def list(self):
+        """Returns a list of file IDs that exist in the Storage"""
+        return []

--- a/depot/io/interfaces.py
+++ b/depot/io/interfaces.py
@@ -212,5 +212,8 @@ class FileStorage(with_metaclass(ABCMeta, object)):
 
     @abstractmethod
     def list(self):
-        """Returns a list of file IDs that exist in the Storage"""
+        """Returns a list of file IDs that exist in the Storage.
+
+        Depending on the implementation there is the possibility that this returns more IDs
+        than there have been created. Therefore this method is NOT guaranteed to be RELIABLE."""
         return []

--- a/depot/io/local.py
+++ b/depot/io/local.py
@@ -147,6 +147,9 @@ class LocalFileStorage(FileStorage):
         local_file_path = self.__local_path(fileid)
         return os.path.exists(local_file_path)
 
+    def list(self):
+        return [os.path.basename(fileid) for fileid in os.listdir(self.storage_path)]
+
 
 def _check_file_id(file_id):
     # Check that the given file id is valid, this also

--- a/tests/test_gridfs_storage.py
+++ b/tests/test_gridfs_storage.py
@@ -1,4 +1,5 @@
 from depot.io.gridfs import GridFSStorage
+from nose import SkipTest
 
 FILE_CONTENT = b'HELLO WORLD'
 

--- a/tests/test_storage_interface.py
+++ b/tests/test_storage_interface.py
@@ -157,6 +157,14 @@ class BaseStorageTestFixture(object):
         self.fs.delete(file_id)
         assert not self.fs.exists(file_id)
 
+    def test_list(self):
+        file_ids = list()
+        for i in range(3):
+            file_ids.append(self.fs.create(FILE_CONTENT, 'file{}.txt'.format(i)))
+
+        for id in self.fs.list():
+            assert id in file_ids
+
     @raises(ValueError)
     def test_exists_invalidid(self):
         self.fs.exists('INVALIDID')
@@ -228,7 +236,6 @@ class TestLocalFileStorage(BaseStorageTestFixture):
 
     def teardown(self):
         shutil.rmtree('./lfs', ignore_errors=True)
-
 
 class TestGridFSFileStorage(BaseStorageTestFixture):
     def setup(self):

--- a/tests/test_storage_interface.py
+++ b/tests/test_storage_interface.py
@@ -164,7 +164,7 @@ class BaseStorageTestFixture(object):
 
         existing_files = self.fs.list()
         for _id in file_ids:
-            assert _id in existing_files, ("{0} from {1} in {2}".format(_id, self.fs.list(), file_ids))
+            assert _id in existing_files, ("{0} not in {1}".format(_id, file_ids))
 
     @raises(ValueError)
     def test_exists_invalidid(self):

--- a/tests/test_storage_interface.py
+++ b/tests/test_storage_interface.py
@@ -162,8 +162,9 @@ class BaseStorageTestFixture(object):
         for i in range(3):
             file_ids.append(self.fs.create(FILE_CONTENT, 'file{0}.txt'.format(i)))
 
-        for _id in self.fs.list():
-            assert _id in file_ids, ("{0} from {1} in {2}".format(_id, self.fs.list(), file_ids))
+        existing_files = self.fs.list()
+        for _id in file_ids:
+            assert _id in existing_files, ("{0} from {1} in {2}".format(_id, self.fs.list(), file_ids))
 
     @raises(ValueError)
     def test_exists_invalidid(self):

--- a/tests/test_storage_interface.py
+++ b/tests/test_storage_interface.py
@@ -162,8 +162,8 @@ class BaseStorageTestFixture(object):
         for i in range(3):
             file_ids.append(self.fs.create(FILE_CONTENT, 'file{}.txt'.format(i)))
 
-        for id in self.fs.list():
-            assert id in file_ids
+        for _id in self.fs.list():
+            assert _id in file_ids, _id
 
     @raises(ValueError)
     def test_exists_invalidid(self):

--- a/tests/test_storage_interface.py
+++ b/tests/test_storage_interface.py
@@ -163,7 +163,7 @@ class BaseStorageTestFixture(object):
             file_ids.append(self.fs.create(FILE_CONTENT, 'file{}.txt'.format(i)))
 
         for _id in self.fs.list():
-            assert _id in file_ids, _id
+            assert _id in file_ids, ("{} in {}".format(_id, file_ids))
 
     @raises(ValueError)
     def test_exists_invalidid(self):

--- a/tests/test_storage_interface.py
+++ b/tests/test_storage_interface.py
@@ -160,10 +160,10 @@ class BaseStorageTestFixture(object):
     def test_list(self):
         file_ids = list()
         for i in range(3):
-            file_ids.append(self.fs.create(FILE_CONTENT, 'file{}.txt'.format(i)))
+            file_ids.append(self.fs.create(FILE_CONTENT, 'file{0}.txt'.format(i)))
 
         for _id in self.fs.list():
-            assert _id in file_ids, ("{} in {}".format(_id, file_ids))
+            assert _id in file_ids, ("{0} from {1} in {2}".format(_id, self.fs.list(), file_ids))
 
     @raises(ValueError)
     def test_exists_invalidid(self):


### PR DESCRIPTION
Implemented possibility to retrieve a list of fileids from the storages.
Couldn't test the gridFS test