### PR TITLE
Ability to specify prefix for S3 storage

### DIFF
--- a/depot/io/awss3.py
+++ b/depot/io/awss3.py
@@ -20,7 +20,6 @@ CANNED_ACL_PRIVATE = 'private'
 
 class S3StoredFile(StoredFile):
     def __init__(self, file_id, key):
-        _check_file_id(file_id)
         self._key = key
 
         metadata_info = {'filename': key.get_metadata('x-depot-filename'),
@@ -88,7 +87,7 @@ class S3Storage(FileStorage):
 
     def get(self, file_or_id):
         fileid = self.fileid(file_or_id)
-        _check_file_id(fileid)
+        self._check_file_id(fileid)
 
         key = self._bucket.get_key(fileid)
         if key is None:
@@ -131,7 +130,7 @@ class S3Storage(FileStorage):
 
     def replace(self, file_or_id, content, filename=None, content_type=None):
         fileid = self.fileid(file_or_id)
-        _check_file_id(fileid)
+        self._check_file_id(fileid)
 
         content, filename, content_type = self.fileinfo(content, filename, content_type)
         if filename is None:
@@ -145,7 +144,7 @@ class S3Storage(FileStorage):
 
     def delete(self, file_or_id):
         fileid = self.fileid(file_or_id)
-        _check_file_id(fileid)
+        self._check_file_id(fileid)
 
         k = self._bucket.get_key(fileid)
         if k:
@@ -153,7 +152,7 @@ class S3Storage(FileStorage):
 
     def exists(self, file_or_id):
         fileid = self.fileid(file_or_id)
-        _check_file_id(fileid)
+        self._check_file_id(fileid)
 
         k = self._bucket.get_key(fileid)
         return k is not None
@@ -161,11 +160,10 @@ class S3Storage(FileStorage):
     def list(self):
         return [key.name for key in self._bucket.list()]
 
-
-def _check_file_id(file_id):
-    # Check that the given file id is valid, this also
-    # prevents unsafe paths.
-    try:
-        uuid.UUID('{%s}' % file_id)
-    except:
-        raise ValueError('Invalid file id %s' % file_id)
+    def _check_file_id(self, file_id):
+        # Check that the given file id is valid, this also
+        # prevents unsafe paths.
+        try:
+            uuid.UUID('{%s}' % file_id)
+        except:
+            raise ValueError('Invalid file id %s' % file_id)

--- a/depot/io/awss3.py
+++ b/depot/io/awss3.py
@@ -80,8 +80,9 @@ class S3Storage(FileStorage):
     connects to using ``access_key_id`` and ``secret_access_key``. If ``host`` is
     omitted the Amazon AWS S3 storage is used. Additionally, a canned ACL policy of
     either ``private`` or ``public-read`` can be specified with the ``policy`` parameter.
-    Finally, the ``encrypt_key`` parameter can be specified to use the server side
-    encryption feature.
+    The ``encrypt_key`` parameter can be specified to use the server side
+    encryption feature. The ``prefix`` parameter can be used to store all files
+    under specified prefix
     """
 
     def __init__(self, access_key_id, secret_access_key, bucket=None, host=None,

--- a/depot/io/awss3.py
+++ b/depot/io/awss3.py
@@ -101,14 +101,14 @@ class S3Storage(FileStorage):
             kw['host'] = host
         self._conn = S3Connection(access_key_id, secret_access_key, **kw)
         bucket = self._conn.lookup(bucket) or self._conn.create_bucket(bucket)
-        self.bucket_driver = BucketDriver(bucket, prefix)
+        self._bucket_driver = BucketDriver(bucket, prefix)
 
 
     def get(self, file_or_id):
         fileid = self.fileid(file_or_id)
         _check_file_id(fileid)
 
-        key = self.bucket_driver.get_key(fileid)
+        key = self._bucket_driver.get_key(fileid)
         if key is None:
             raise IOError('File %s not existing' % fileid)
 
@@ -143,7 +143,7 @@ class S3Storage(FileStorage):
     def create(self, content, filename=None, content_type=None):
         content, filename, content_type = self.fileinfo(content, filename, content_type)
         new_file_id = str(uuid.uuid1())
-        key = self.bucket_driver.new_key(new_file_id)
+        key = self._bucket_driver.new_key(new_file_id)
         self.__save_file(key, content, filename, content_type)
         return new_file_id
 
@@ -157,7 +157,7 @@ class S3Storage(FileStorage):
             filename = f.filename
             content_type = f.content_type
 
-        key = self.bucket_driver.get_key(fileid)
+        key = self._bucket_driver.get_key(fileid)
         self.__save_file(key, content, filename, content_type)
         return fileid
 
@@ -165,7 +165,7 @@ class S3Storage(FileStorage):
         fileid = self.fileid(file_or_id)
         _check_file_id(fileid)
 
-        k = self.bucket_driver.get_key(fileid)
+        k = self._bucket_driver.get_key(fileid)
         if k:
             k.delete()
 
@@ -173,11 +173,11 @@ class S3Storage(FileStorage):
         fileid = self.fileid(file_or_id)
         _check_file_id(fileid)
 
-        k = self.bucket_driver.get_key(fileid)
+        k = self._bucket_driver.get_key(fileid)
         return k is not None
 
     def list(self):
-        return self.bucket_driver.list_key_names()
+        return self._bucket_driver.list_key_names()
 
 
 def _check_file_id(file_id):

--- a/depot/io/awss3.py
+++ b/depot/io/awss3.py
@@ -82,7 +82,7 @@ class S3Storage(FileStorage):
     either ``private`` or ``public-read`` can be specified with the ``policy`` parameter.
     The ``encrypt_key`` parameter can be specified to use the server side
     encryption feature. The ``prefix`` parameter can be used to store all files
-    under specified prefix
+    under specified prefix.
     """
 
     def __init__(self, access_key_id, secret_access_key, bucket=None, host=None,

--- a/depot/io/awss3.py
+++ b/depot/io/awss3.py
@@ -20,6 +20,7 @@ CANNED_ACL_PRIVATE = 'private'
 
 class S3StoredFile(StoredFile):
     def __init__(self, file_id, key):
+        _check_file_id(file_id)
         self._key = key
 
         metadata_info = {'filename': key.get_metadata('x-depot-filename'),
@@ -104,7 +105,7 @@ class S3Storage(FileStorage):
 
     def get(self, file_or_id):
         fileid = self.fileid(file_or_id)
-        self._check_file_id(fileid)
+        _check_file_id(fileid)
 
         key = self.bucket_driver.get_key(fileid)
         if key is None:
@@ -147,7 +148,7 @@ class S3Storage(FileStorage):
 
     def replace(self, file_or_id, content, filename=None, content_type=None):
         fileid = self.fileid(file_or_id)
-        self._check_file_id(fileid)
+        _check_file_id(fileid)
 
         content, filename, content_type = self.fileinfo(content, filename, content_type)
         if filename is None:
@@ -161,7 +162,7 @@ class S3Storage(FileStorage):
 
     def delete(self, file_or_id):
         fileid = self.fileid(file_or_id)
-        self._check_file_id(fileid)
+        _check_file_id(fileid)
 
         k = self.bucket_driver.get_key(fileid)
         if k:
@@ -169,7 +170,7 @@ class S3Storage(FileStorage):
 
     def exists(self, file_or_id):
         fileid = self.fileid(file_or_id)
-        self._check_file_id(fileid)
+        _check_file_id(fileid)
 
         k = self.bucket_driver.get_key(fileid)
         return k is not None
@@ -177,10 +178,11 @@ class S3Storage(FileStorage):
     def list(self):
         return self.bucket_driver.list_key_names()
 
-    def _check_file_id(self, file_id):
-        # Check that the given file id is valid, this also
-        # prevents unsafe paths.
-        try:
-            uuid.UUID('{%s}' % file_id)
-        except:
-            raise ValueError('Invalid file id %s' % file_id)
+
+def _check_file_id(file_id):
+    # Check that the given file id is valid, this also
+    # prevents unsafe paths.
+    try:
+        uuid.UUID('{%s}' % file_id)
+    except:
+        raise ValueError('Invalid file id %s' % file_id)

--- a/depot/io/awss3.py
+++ b/depot/io/awss3.py
@@ -55,6 +55,23 @@ class S3StoredFile(StoredFile):
         return self._key.generate_url(expires_in=0, query_auth=False)
 
 
+class BucketDriver(object):
+
+    def __init__(self, bucket, prefix):
+        self.bucket = bucket
+        self.prefix = prefix
+
+    def get_key(self, key_name):
+        return self.bucket.get_key('%s%s' % (self.prefix, key_name))
+
+    def new_key(self, key_name):
+        return self.bucket.new_key('%s%s' % (self.prefix, key_name))
+
+    def list_key_names(self):
+        keys = self.bucket.list(prefix=self.prefix)
+        return [k.name[len(self.prefix):] for k in keys]
+
+
 class S3Storage(FileStorage):
     """:class:`depot.io.interfaces.FileStorage` implementation that stores files on S3.
 
@@ -67,7 +84,7 @@ class S3Storage(FileStorage):
     """
 
     def __init__(self, access_key_id, secret_access_key, bucket=None, host=None,
-                 policy=None, encrypt_key=False):
+                 policy=None, encrypt_key=False, prefix=''):
         policy = policy or CANNED_ACL_PUBLIC_READ
         assert policy in [CANNED_ACL_PUBLIC_READ, CANNED_ACL_PRIVATE], (
             "Key policy must be %s or %s" % (CANNED_ACL_PUBLIC_READ, CANNED_ACL_PRIVATE))
@@ -81,15 +98,15 @@ class S3Storage(FileStorage):
         if host is not None:
             kw['host'] = host
         self._conn = S3Connection(access_key_id, secret_access_key, **kw)
-        self._bucket = self._conn.lookup(bucket)
-        if self._bucket is None:
-            self._bucket = self._conn.create_bucket(bucket)
+        bucket = self._conn.lookup(bucket) or self._conn.create_bucket(bucket)
+        self.bucket_driver = BucketDriver(bucket, prefix)
+
 
     def get(self, file_or_id):
         fileid = self.fileid(file_or_id)
         self._check_file_id(fileid)
 
-        key = self._bucket.get_key(fileid)
+        key = self.bucket_driver.get_key(fileid)
         if key is None:
             raise IOError('File %s not existing' % fileid)
 
@@ -121,13 +138,10 @@ class S3Storage(FileStorage):
             key.set_contents_from_string(content, policy=self._policy,
                                          encrypt_key=self._encrypt_key)
 
-    def _get_new_file_id(self):
-        return str(uuid.uuid1())
-
     def create(self, content, filename=None, content_type=None):
         content, filename, content_type = self.fileinfo(content, filename, content_type)
-        new_file_id = self._get_new_file_id()
-        key = self._bucket.new_key(new_file_id)
+        new_file_id = str(uuid.uuid1())
+        key = self.bucket_driver.new_key(new_file_id)
         self.__save_file(key, content, filename, content_type)
         return new_file_id
 
@@ -141,7 +155,7 @@ class S3Storage(FileStorage):
             filename = f.filename
             content_type = f.content_type
 
-        key = self._bucket.get_key(fileid)
+        key = self.bucket_driver.get_key(fileid)
         self.__save_file(key, content, filename, content_type)
         return fileid
 
@@ -149,7 +163,7 @@ class S3Storage(FileStorage):
         fileid = self.fileid(file_or_id)
         self._check_file_id(fileid)
 
-        k = self._bucket.get_key(fileid)
+        k = self.bucket_driver.get_key(fileid)
         if k:
             k.delete()
 
@@ -157,11 +171,11 @@ class S3Storage(FileStorage):
         fileid = self.fileid(file_or_id)
         self._check_file_id(fileid)
 
-        k = self._bucket.get_key(fileid)
+        k = self.bucket_driver.get_key(fileid)
         return k is not None
 
     def list(self):
-        return [key.name for key in self._bucket.list()]
+        return self.bucket_driver.list_key_names()
 
     def _check_file_id(self, file_id):
         # Check that the given file id is valid, this also
@@ -170,24 +184,3 @@ class S3Storage(FileStorage):
             uuid.UUID('{%s}' % file_id)
         except:
             raise ValueError('Invalid file id %s' % file_id)
-
-
-class S3PrefixedStorage(S3Storage):
-
-    def __init__(self, *args, **kwargs):
-        self._prefix = kwargs.pop('prefix')
-        super(S3PrefixedStorage, self).__init__(*args, **kwargs)
-
-    def _get_new_file_id(self):
-        new_file_id = super(S3PrefixedStorage, self)._get_new_file_id()
-        return '%s%s' % (self._prefix, new_file_id)
-
-    def _check_file_id(self, file_id):
-        # Check that the given file id is valid, this also
-        # prevents unsafe paths.
-        if file_id.startswith(self._prefix):
-            file_id = file_id[len(self._prefix):]
-        super(S3PrefixedStorage, self)._check_file_id(file_id)
-
-    def list(self):
-        return [key.name for key in self._bucket.list(prefix=self._prefix)]

--- a/tests/test_awss3_storage.py
+++ b/tests/test_awss3_storage.py
@@ -31,7 +31,7 @@ class TestS3FileStorage(object):
 
     def test_fileoutside_depot(self):
         fid = str(uuid.uuid1())
-        key = self.fs.bucket_driver.new_key(fid)
+        key = self.fs._bucket_driver.new_key(fid)
         key.set_contents_from_string(FILE_CONTENT)
 
         f = self.fs.get(fid)
@@ -39,7 +39,7 @@ class TestS3FileStorage(object):
 
     def test_invalid_modified(self):
         fid = str(uuid.uuid1())
-        key = self.fs.bucket_driver.new_key(fid)
+        key = self.fs._bucket_driver.new_key(fid)
         key.set_metadata('x-depot-modified', 'INVALID')
         key.set_contents_from_string(FILE_CONTENT)
 
@@ -56,11 +56,11 @@ class TestS3FileStorage(object):
     def test_default_bucket_name(self):
         with mock.patch('boto.s3.connection.S3Connection.lookup', return_value='YES'):
             fs = S3Storage(*self.cred)
-            assert fs.bucket_driver.bucket == 'YES'
+            assert fs._bucket_driver.bucket == 'YES'
 
     def test_public_url(self):
         fid = str(uuid.uuid1())
-        key = self.fs.bucket_driver.new_key(fid)
+        key = self.fs._bucket_driver.new_key(fid)
         key.set_contents_from_string(FILE_CONTENT)
 
         f = self.fs.get(fid)
@@ -68,11 +68,11 @@ class TestS3FileStorage(object):
         assert f.public_url.endswith('/%s' % fid), f.public_url
 
     def teardown(self):
-        keys = [key.name for key in self.fs.bucket_driver.bucket]
+        keys = [key.name for key in self.fs._bucket_driver.bucket]
         if keys:
-            self.fs.bucket_driver.bucket.delete_keys(keys)
+            self.fs._bucket_driver.bucket.delete_keys(keys)
 
         try:
-            self.fs._conn.delete_bucket(self.fs.bucket_driver.bucket.name)
+            self.fs._conn.delete_bucket(self.fs._bucket_driver.bucket.name)
         except:
             pass

--- a/tests/test_awss3_storage.py
+++ b/tests/test_awss3_storage.py
@@ -31,7 +31,7 @@ class TestS3FileStorage(object):
 
     def test_fileoutside_depot(self):
         fid = str(uuid.uuid1())
-        key = self.fs._bucket.new_key(fid)
+        key = self.fs.bucket_driver.new_key(fid)
         key.set_contents_from_string(FILE_CONTENT)
 
         f = self.fs.get(fid)
@@ -39,7 +39,7 @@ class TestS3FileStorage(object):
 
     def test_invalid_modified(self):
         fid = str(uuid.uuid1())
-        key = self.fs._bucket.new_key(fid)
+        key = self.fs.bucket_driver.new_key(fid)
         key.set_metadata('x-depot-modified', 'INVALID')
         key.set_contents_from_string(FILE_CONTENT)
 
@@ -56,11 +56,11 @@ class TestS3FileStorage(object):
     def test_default_bucket_name(self):
         with mock.patch('boto.s3.connection.S3Connection.lookup', return_value='YES'):
             fs = S3Storage(*self.cred)
-            assert fs._bucket == 'YES'
+            assert fs.bucket_driver.bucket == 'YES'
 
     def test_public_url(self):
         fid = str(uuid.uuid1())
-        key = self.fs._bucket.new_key(fid)
+        key = self.fs.bucket_driver.new_key(fid)
         key.set_contents_from_string(FILE_CONTENT)
 
         f = self.fs.get(fid)
@@ -68,11 +68,11 @@ class TestS3FileStorage(object):
         assert f.public_url.endswith('/%s' % fid), f.public_url
 
     def teardown(self):
-        keys = [key.name for key in self.fs._bucket]
+        keys = [key.name for key in self.fs.bucket_driver.bucket]
         if keys:
-            self.fs._bucket.delete_keys(keys)
+            self.fs.bucket_driver.bucket.delete_keys(keys)
 
         try:
-            self.fs._conn.delete_bucket(self.fs._bucket.name)
+            self.fs._conn.delete_bucket(self.fs.bucket_driver.bucket.name)
         except:
             pass

--- a/tests/test_storage_interface.py
+++ b/tests/test_storage_interface.py
@@ -253,6 +253,12 @@ class TestGridFSFileStorage(BaseStorageTestFixture):
 
 
 class TestS3FileStorage(BaseStorageTestFixture):
+
+    @classmethod
+    def get_storage(cls, access_key_id, secret_access_key, bucket_name):
+        from depot.io.awss3 import S3Storage
+        return S3Storage(access_key_id, secret_access_key, bucket_name)
+
     @classmethod
     def setup_class(cls):
         try:
@@ -269,7 +275,7 @@ class TestS3FileStorage(BaseStorageTestFixture):
         PID = os.getpid()
         NODE = str(uuid.uuid1()).rsplit('-', 1)[-1]
         BUCKET_NAME = 'fdtest-%s-%s-%s' % (access_key_id.lower(), NODE, PID)
-        cls.fs = S3Storage(access_key_id, secret_access_key, BUCKET_NAME)
+        cls.fs = cls.get_storage(access_key_id, secret_access_key, BUCKET_NAME)
 
     def teardown(self):
         keys = [key.name for key in self.fs._bucket]
@@ -282,3 +288,15 @@ class TestS3FileStorage(BaseStorageTestFixture):
             cls.fs._conn.delete_bucket(cls.fs._bucket.name)
         except:
             pass
+
+
+class TestS3PrefixedFileStorage(TestS3FileStorage):
+
+    @classmethod
+    def get_storage(cls, access_key_id, secret_access_key, bucket_name):
+        from depot.io.awss3 import S3PrefixedStorage
+        return S3PrefixedStorage(
+            access_key_id,
+            secret_access_key,
+            bucket_name,
+            prefix='my-prefix/')

--- a/tests/test_storage_interface.py
+++ b/tests/test_storage_interface.py
@@ -278,24 +278,24 @@ class TestS3FileStorage(BaseStorageTestFixture):
         cls.fs = cls.get_storage(access_key_id, secret_access_key, BUCKET_NAME)
 
     def teardown(self):
-        keys = [key.name for key in self.fs._bucket]
+        keys = [key.name for key in self.fs.bucket_driver.bucket]
         if keys:
-            self.fs._bucket.delete_keys(keys)
+            self.fs.bucket_driver.bucket.delete_keys(keys)
 
     @classmethod
     def teardown_class(cls):
         try:
-            cls.fs._conn.delete_bucket(cls.fs._bucket.name)
+            cls.fs._conn.delete_bucket(cls.fs.bucket_driver.bucket.name)
         except:
             pass
 
 
-class TestS3PrefixedFileStorage(TestS3FileStorage):
+class TestS3FileStorageWithPrefix(TestS3FileStorage):
 
     @classmethod
     def get_storage(cls, access_key_id, secret_access_key, bucket_name):
-        from depot.io.awss3 import S3PrefixedStorage
-        return S3PrefixedStorage(
+        from depot.io.awss3 import S3Storage
+        return S3Storage(
             access_key_id,
             secret_access_key,
             bucket_name,

--- a/tests/test_storage_interface.py
+++ b/tests/test_storage_interface.py
@@ -278,14 +278,14 @@ class TestS3FileStorage(BaseStorageTestFixture):
         cls.fs = cls.get_storage(access_key_id, secret_access_key, BUCKET_NAME)
 
     def teardown(self):
-        keys = [key.name for key in self.fs.bucket_driver.bucket]
+        keys = [key.name for key in self.fs._bucket_driver.bucket]
         if keys:
-            self.fs.bucket_driver.bucket.delete_keys(keys)
+            self.fs._bucket_driver.bucket.delete_keys(keys)
 
     @classmethod
     def teardown_class(cls):
         try:
-            cls.fs._conn.delete_bucket(cls.fs.bucket_driver.bucket.name)
+            cls.fs._conn.delete_bucket(cls.fs._bucket_driver.bucket.name)
         except:
             pass
 


### PR DESCRIPTION
This change adds S3PrefixedStorage class which extends S3Storage with "prefix" required argument.
I thought it would be nice to be ale to store all files within one folder in S3. So, I implemented it after reviewing this discussion:
https://github.com/amol-/depot/issues/13#issuecomment-142432557
As suggested, prefix here is set in storage, not in the file field.

Can you please review and provide feedback? One thing I am not sure about in this implementation is that prefix ends up in UploadedFile['file_id']. Perhaps it would be more clear to not leak prefix outside of the storage class.