### PR TITLE
Update S3Storage to set "unknown" filename when creating from bytestring

### DIFF
--- a/depot/io/awss3.py
+++ b/depot/io/awss3.py
@@ -153,7 +153,7 @@ class S3Storage(FileStorage):
         content, filename, content_type = self.fileinfo(content, filename, content_type)
         new_file_id = str(uuid.uuid1())
         key = self._bucket_driver.new_key(new_file_id)
-        self.__save_file(key, content, filename, content_type)
+        self.__save_file(key, content, filename or 'unknown', content_type)
         return new_file_id
 
     def replace(self, file_or_id, content, filename=None, content_type=None):
@@ -167,7 +167,7 @@ class S3Storage(FileStorage):
             content_type = f.content_type
 
         key = self._bucket_driver.get_key(fileid)
-        self.__save_file(key, content, filename, content_type)
+        self.__save_file(key, content, filename or 'unknown', content_type)
         return fileid
 
     def delete(self, file_or_id):

--- a/depot/io/local.py
+++ b/depot/io/local.py
@@ -97,7 +97,7 @@ class LocalFileStorage(FileStorage):
                 fileobj.write(content)
                 fileobj.flush()
 
-        metadata = {'filename': filename or 'unknown',
+        metadata = {'filename': filename,
                     'content_type': content_type,
                     'content_length': os.path.getsize(saved_file_path),
                     'last_modified': utils.timestamp()}
@@ -108,7 +108,7 @@ class LocalFileStorage(FileStorage):
     def create(self, content, filename=None, content_type=None):
         new_file_id = str(uuid.uuid1())
         content, filename, content_type = self.fileinfo(content, filename, content_type)
-        self.__save_file(new_file_id, content, filename, content_type)
+        self.__save_file(new_file_id, content, filename or 'unknown', content_type)
         return new_file_id
 
     def replace(self, file_or_id, content, filename=None, content_type=None):
@@ -127,7 +127,7 @@ class LocalFileStorage(FileStorage):
             content_type = f.content_type
 
         self.delete(fileid)
-        self.__save_file(fileid, content, filename, content_type)
+        self.__save_file(fileid, content, filename or 'unknown', content_type)
         return fileid
 
     def delete(self, file_or_id):

--- a/tests/test_storage_interface.py
+++ b/tests/test_storage_interface.py
@@ -229,6 +229,11 @@ class BaseStorageTestFixture(object):
         f = self.fs.get(file_id)
         assert f.name == f.filename
 
+    def test_create_from_bytes(self):
+        file_id = self.fs.create('this is the content')
+        f = self.fs.get(file_id)
+        assert f.name == 'unknown'
+
 
 class TestLocalFileStorage(BaseStorageTestFixture):
     def setup(self):

--- a/tests/test_storage_interface.py
+++ b/tests/test_storage_interface.py
@@ -230,7 +230,7 @@ class BaseStorageTestFixture(object):
         assert f.name == f.filename
 
     def test_create_from_bytes(self):
-        file_id = self.fs.create('this is the content')
+        file_id = self.fs.create(b'this is the content')
         f = self.fs.get(file_id)
         assert f.name == 'unknown'
 


### PR DESCRIPTION
Otherwise (if filename is None) boto fails with BadSignature