### PR TITLE
Fixed Oracle "ORA-00910: specified length too long for its datatype." error for UploadedFileField type

### DIFF
--- a/depot/fields/sqlalchemy.py
+++ b/depot/fields/sqlalchemy.py
@@ -40,7 +40,7 @@ class UploadedFileField(types.TypeDecorator):
         self._upload_storage = upload_storage
 
     def load_dialect_impl(self, dialect):
-        return dialect.type_descriptor(types.VARCHAR(4096))
+        return dialect.type_descriptor(types.VARCHAR(4000))
 
     def process_bind_param(self, value, dialect):
         if not value:


### PR DESCRIPTION
Use `VARCHAR` of size 4000 instead of 4096 as 4000 is the maximum size allowed for this type in Oracle. Using generic type `String` would be better but there's problem with Alembic – see https://github.com/amol-/depot/issues/26#issuecomment-207602830
Closes issue #26.