### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Installing DEPOT can be done from PyPi itself by installing the ``filedepot`` di
 Getting Started
 ---------------
 
-To start using Depot refer to `Documentation <http://depot.readthedocs.org/en/latest/>`_
+To start using Depot refer to `Documentation <https://depot.readthedocs.io/en/latest/>`_
 
 DEPOT was `presented at PyConUK and PyConFR <http://www.slideshare.net/__amol__/pyconfr-2014-depot-story-of-a-filewrite-gone-wrong>`_ in 2014
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.