### PR TITLE
Fix an issue causing UnicodeDecodeError during installation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,7 +94,7 @@ ChangeLog
 
 - It is now possible to use multiple ``WithThumbnailFilter`` to generate multiple thumbnails
   with different resolutions.
-- Better documentation for MongoDB ``UploadedFileProperty`` 
+- Better documentation for MongoDB ``UploadedFileProperty``
 
 0.1.1
 ~~~~~


### PR DESCRIPTION
During installation, if the system's language is not using UTF-8 encoding (for example, `LANG=C`) Python (tested with 3.5) will throw out an `UnicodeDecodeError` when reading the content from `README.rst` like this:

```
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 2881: ordinal not in range(128)
```

The problem is caused by a `\xc2\xa0` space after the "UploadedFileProperty" in section 0.1.2 of `README.rst`. This pull request removed the invisible space.