### PR TITLE
Add support for upload stream

### DIFF
--- a/depot/fields/upload.py
+++ b/depot/fields/upload.py
@@ -71,3 +71,29 @@ class UploadedFile(DepotFileInfo):
     @property
     def file(self):
         return self.depot.get(self.file_id)
+
+
+class UploadedId(UploadedFile):
+    """Wrapper for class:`depot.fields.upload.UploadedFile`.
+
+    Allow process already uploaded file by it's id
+    """
+    def process_content(self, content, filename=None, content_type=None):
+        """Implementation of :meth:`.DepotFileInfo.process_content`
+
+        Allow process already uploaded file by it's Depot ID instead of file.
+        :param content: Depot ID
+        """
+
+        file_id = content
+        file_path = '%s/%s' % (self.depot_name, file_id)
+        self.files.append(file_path)
+
+        self['file_id'] = file_id
+        self['path'] = file_path
+
+        saved_file = self.file
+        self['filename'] = saved_file.filename
+        self['content_type'] = saved_file.content_type
+        self['uploaded_at'] = saved_file.last_modified.strftime('%Y-%m-%d %H:%M:%S')
+        self['_public_url'] = saved_file.public_url

--- a/depot/io/gridfs.py
+++ b/depot/io/gridfs.py
@@ -27,10 +27,9 @@ class GridFSStoredFile(StoredFile):
                          'last_modified': None}
 
         try:
-            last_modified = gridout.last_modified
+            last_modified = gridout.upload_date
             if last_modified:
-                metadata_info['last_modified'] = datetime.strptime(last_modified,
-                                                                   '%Y-%m-%d %H:%M:%S')
+                metadata_info['last_modified'] = last_modified
         except:
             pass
 

--- a/depot/io/gridfs.py
+++ b/depot/io/gridfs.py
@@ -62,6 +62,7 @@ class GridFSStorage(FileStorage):
         self._cli = MongoClient(mongouri)
         self._db = self._cli.get_default_database()
         self._gridfs = gridfs.GridFS(self._db, collection=collection)
+        self._gridfs_bucket = gridfs.GridFSBucket(self._db, bucket_name=collection)
 
     def get(self, file_or_id):
         fileid = self.fileid(file_or_id)
@@ -80,6 +81,17 @@ class GridFSStorage(FileStorage):
                                        content_type=content_type,
                                        last_modified=utils.timestamp())
         return str(new_file_id)
+
+    def create_stream(self, filename=None, content_type=None):
+        if not content_type:
+            content_type = utils._FileInfo.DEFAULT_CONTENT_TYPE
+        if not filename:
+            filename = utils._FileInfo.DEFAULT_NAME
+
+        metadata = {'contentType': content_type}
+        stream, new_file_id = self._gridfs_bucket.open_upload_stream(filename, metadata=metadata)
+
+        return stream, str(new_file_id)
 
     def replace(self, file_or_id, content, filename=None, content_type=None):
         fileid = self.fileid(file_or_id)

--- a/depot/io/gridfs.py
+++ b/depot/io/gridfs.py
@@ -88,7 +88,8 @@ class GridFSStorage(FileStorage):
             filename = utils._FileInfo.DEFAULT_NAME
 
         metadata = {'contentType': content_type}
-        stream, new_file_id = self._gridfs_bucket.open_upload_stream(filename, metadata=metadata)
+        stream = self._gridfs_bucket.open_upload_stream(filename, metadata=metadata)
+        new_file_id = stream._id
         setattr(stream, 'file_id', str(new_file_id))
 
         return stream

--- a/depot/io/gridfs.py
+++ b/depot/io/gridfs.py
@@ -90,8 +90,9 @@ class GridFSStorage(FileStorage):
 
         metadata = {'contentType': content_type}
         stream, new_file_id = self._gridfs_bucket.open_upload_stream(filename, metadata=metadata)
+        setattr(stream, 'file_id', str(new_file_id))
 
-        return stream, str(new_file_id)
+        return stream
 
     def replace(self, file_or_id, content, filename=None, content_type=None):
         fileid = self.fileid(file_or_id)

--- a/depot/io/interfaces.py
+++ b/depot/io/interfaces.py
@@ -163,7 +163,7 @@ class FileStorage(with_metaclass(ABCMeta, object)):
 
     @abstractmethod
     def create_stream(self, filename=None, content_type=None):
-        """Create byte-stream like object and returns it and the ID of newly created file.
+        """Create byte-stream like object and returns it with attribute ``file_id``.
 
         Typically stream contain write and close methods.
         After usage stream must be closed.

--- a/depot/io/interfaces.py
+++ b/depot/io/interfaces.py
@@ -162,6 +162,15 @@ class FileStorage(with_metaclass(ABCMeta, object)):
         return
 
     @abstractmethod
+    def create_stream(self, filename=None, content_type=None):
+        """Create byte-stream like object and returns it and the ID of newly created file.
+
+        Typically stream contain write and close methods.
+        After usage stream must be closed.
+        """
+        return
+
+    @abstractmethod
     def replace(self, file_or_id, content, filename=None, content_type=None):  # pragma: no cover
         """Replaces an existing file, an ``IOError`` is raised if the file didn't already exist.
 

--- a/depot/io/local.py
+++ b/depot/io/local.py
@@ -111,6 +111,30 @@ class LocalFileStorage(FileStorage):
         self.__save_file(new_file_id, content, filename, content_type)
         return new_file_id
 
+    def create_stream(self, filename=None, content_type=None):
+        new_file_id = str(uuid.uuid1())
+        if not content_type:
+            content_type = utils._FileInfo.DEFAULT_CONTENT_TYPE
+        if not filename:
+            filename = utils._FileInfo.DEFAULT_NAME
+
+        local_file_path = self.__local_path(new_file_id)
+        os.makedirs(local_file_path)
+        saved_file_path = _file_path(local_file_path)
+
+        stream = open(saved_file_path, 'wb')
+
+        metadata = {'filename': filename,
+                    'content_type': content_type,
+                    'content_length': os.path.getsize(saved_file_path),
+                    'last_modified': utils.timestamp()}
+        with open(_metadata_path(local_file_path), 'w') as metadatafile:
+            metadatafile.write(json.dumps(metadata))
+
+        setattr(stream, 'file_id', new_file_id)
+
+        return stream
+
     def replace(self, file_or_id, content, filename=None, content_type=None):
         fileid = self.fileid(file_or_id)
         _check_file_id(fileid)


### PR DESCRIPTION
Sometimes we need to upload large files into storage or pass stream to another function.
We had only one way before - put file into filesystem and then pass file descriptor to depot, but it requires some space in the filesystem and file processing time increases.
I've added ``create_stream`` method for the interface and created local storage and GridFS implementations.