### PR TITLE
Remove unidecode

### DIFF
--- a/depot/utils.py
+++ b/depot/utils.py
@@ -2,15 +2,15 @@ from ._compat import percent_encode
 
 try:
     from unidecode import unidecode as fix_chars
-except:
+except ImportError:
     import sys
     from unicodedata import normalize
     if (sys.version_info > (3, 0)):
         from urllib.parse import quote
     else:
         from urllib import quote
-    def fix_chars(str):
-        return quote(normalize('NFKC', str))
+    def fix_chars(string):
+        return quote(normalize('NFKC', string))
 
 def make_content_disposition(disposition, fname):
     rfc6266_part = "filename*=utf-8''%s" % (percent_encode(fname, safe='!#$&+-.^_`|~', encoding='utf-8'), )

--- a/depot/utils.py
+++ b/depot/utils.py
@@ -1,12 +1,11 @@
+from ._compat import percent_encode
+
 try:
     from unidecode import unidecode as fix_chars
 except:
     from unicodedata import normalize
-    import urllib.parse
     def fix_chars(str):
-        return urllib.parse.quote(normalize('NFKC', str))
-from ._compat import percent_encode
-
+        return percent_encode(normalize('NFKC', str))
 
 def make_content_disposition(disposition, fname):
     rfc6266_part = "filename*=utf-8''%s" % (percent_encode(fname, safe='!#$&+-.^_`|~', encoding='utf-8'), )

--- a/depot/utils.py
+++ b/depot/utils.py
@@ -3,9 +3,14 @@ from ._compat import percent_encode
 try:
     from unidecode import unidecode as fix_chars
 except:
+    import sys
     from unicodedata import normalize
+    if (sys.version_info > (3, 0)):
+        from urllib.parse import quote
+    else:
+        from urllib import quote
     def fix_chars(str):
-        return percent_encode(normalize('NFKC', str))
+        return quote(normalize('NFKC', str))
 
 def make_content_disposition(disposition, fname):
     rfc6266_part = "filename*=utf-8''%s" % (percent_encode(fname, safe='!#$&+-.^_`|~', encoding='utf-8'), )

--- a/depot/utils.py
+++ b/depot/utils.py
@@ -2,8 +2,9 @@ try:
     from unidecode import unidecode as fix_chars
 except:
     from unicodedata import normalize
+    import urllib.parse
     def fix_chars(str):
-        normalize('NFKC', str).encode('ascii','ignore').decode('ascii')
+        return urllib.parse.quote(normalize('NFKC', str))
 from ._compat import percent_encode
 
 

--- a/depot/utils.py
+++ b/depot/utils.py
@@ -3,14 +3,9 @@ from ._compat import percent_encode
 try:
     from unidecode import unidecode as fix_chars
 except ImportError:
-    import sys
     from unicodedata import normalize
-    if (sys.version_info > (3, 0)):
-        from urllib.parse import quote
-    else:
-        from urllib import quote
     def fix_chars(string):
-        return quote(normalize('NFKC', string))
+        return percent_encode(normalize('NFKC', string), safe='!#$&+-.^_`|~', encoding='utf-8')
 
 def make_content_disposition(disposition, fname):
     rfc6266_part = "filename*=utf-8''%s" % (percent_encode(fname, safe='!#$&+-.^_`|~', encoding='utf-8'), )

--- a/depot/utils.py
+++ b/depot/utils.py
@@ -1,8 +1,13 @@
-from unidecode import unidecode
+try:
+    from unidecode import unidecode as fix_chars
+except:
+    from unicodedata import normalize
+    def fix_chars(str):
+        normalize('NFKC', str).encode('ascii','ignore').decode('ascii')
 from ._compat import percent_encode
 
 
 def make_content_disposition(disposition, fname):
     rfc6266_part = "filename*=utf-8''%s" % (percent_encode(fname, safe='!#$&+-.^_`|~', encoding='utf-8'), )
-    ascii_part = 'filename="%s"' % (unidecode(fname), )
+    ascii_part = 'filename="%s"' % (fix_chars(fname), )
     return ';'.join((disposition, ascii_part, rfc6266_part))

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ else:
     TEST_DEPENDENCIES += ['coverage < 4.0']
 
 
-INSTALL_DEPENDENCIES = ['unidecode']
+INSTALL_DEPENDENCIES = []
 if py_version == (2, 6):
     INSTALL_DEPENDENCIES += ['importlib']
     TEST_DEPENDENCIES += ['ordereddict', 'pillow < 4.0.0', 'WebTest < 2.0.24', 'sqlalchemy < 1.2']


### PR DESCRIPTION
Fixes #64 by using URL encoding when unidecode isn't installed. It also removes the dependency on unidocde so that it is only installed when users want it/can use it.