### PR TITLE
Replace unidecode with anyascii

### DIFF
--- a/depot/utils.py
+++ b/depot/utils.py
@@ -1,8 +1,17 @@
-from unidecode import unidecode
-from ._compat import percent_encode
+from ._compat import percent_encode, unicode_text
+
+try:
+    from anyascii import anyascii
+except ImportError:
+    # Python2 doesn't support anyascii
+    import unicodedata
+    def anyascii(text):
+        if not isinstance(text, unicode_text):
+            text = text.decode("utf-8")
+        return unicodedata.normalize("NFKD", text).encode("ascii", "ignore") or "unknown"
 
 
 def make_content_disposition(disposition, fname):
     rfc6266_part = "filename*=utf-8''%s" % (percent_encode(fname, safe='!#$&+-.^_`|~', encoding='utf-8'), )
-    ascii_part = 'filename="%s"' % (unidecode(fname), )
+    ascii_part = 'filename="%s"' % (anyascii(fname), )
     return ';'.join((disposition, ascii_part, rfc6266_part))

--- a/setup.py
+++ b/setup.py
@@ -22,10 +22,9 @@ if py_version != (3, 2):
 else:
     TEST_DEPENDENCIES += ['coverage < 4.0']
 
-if py_version > (3, 0):
-    INSTALL_DEPENDENCIES = ["anyascii"]
-else:
-    INSTALL_DEPENDENCIES = []
+INSTALL_DEPENDENCIES = []
+if py_version >= (3, 0):
+    INSTALL_DEPENDENCIES += ["anyascii"]
 
 if py_version == (2, 6):
     INSTALL_DEPENDENCIES += ['importlib']

--- a/setup.py
+++ b/setup.py
@@ -22,13 +22,17 @@ if py_version != (3, 2):
 else:
     TEST_DEPENDENCIES += ['coverage < 4.0']
 
+if py_version > (3, 0):
+    INSTALL_DEPENDENCIES = ["anyascii"]
+else:
+    INSTALL_DEPENDENCIES = []
 
-INSTALL_DEPENDENCIES = ['unidecode']
 if py_version == (2, 6):
     INSTALL_DEPENDENCIES += ['importlib']
     TEST_DEPENDENCIES += ['ordereddict', 'pillow < 4.0.0', 'WebTest < 2.0.24', 'sqlalchemy < 1.2']
 else:
     TEST_DEPENDENCIES += ['pillow', 'WebTest', 'sqlalchemy']
+
 
 
 setup(name='filedepot',

--- a/tests/test_wsgi_middleware.py
+++ b/tests/test_wsgi_middleware.py
@@ -7,7 +7,7 @@ import uuid
 from depot.manager import DepotManager
 from tg import expose, TGController, AppConfig
 from webtest import TestApp
-from depot._compat import u_, unquote
+from depot._compat import u_, unquote, PY2
 
 
 FILE_CONTENT = b'HELLO WORLD'
@@ -177,7 +177,12 @@ class TestWSGIMiddleware(BaseWSGITests):
 
         uploaded_file = app.get(DepotManager.url_for('%(uploaded_to)s/%(last)s' % new_file))
         content_disposition = uploaded_file.headers['Content-Disposition']
-        assert content_disposition == "inline;filename=\"Krupnyi\";filename*=utf-8''%D0%9A%D1%80%D1%83%D0%BF%D0%BD%D1%8B%D0%B9", content_disposition
+
+        if PY2:
+            assert content_disposition == "inline;filename=\"unknown\";filename*=utf-8''%D0%9A%D1%80%D1%83%D0%BF%D0%BD%D1%8B%D0%B9", content_disposition
+        else:
+            assert content_disposition == "inline;filename=\"Krupnyy\";filename*=utf-8''%D0%9A%D1%80%D1%83%D0%BF%D0%BD%D1%8B%D0%B9", content_disposition
+
 
         new_file = app.post('/create_file', params={'lang': 'it'}).json
         uploaded_file = app.get(DepotManager.url_for('%(uploaded_to)s/%(last)s' % new_file))


### PR DESCRIPTION
anyascii is license compatible with DEPOT, while unidecode was GPL