### PR TITLE
Added support for setting file IDs explicitly. 

### DIFF
--- a/depot/io/awss3.py
+++ b/depot/io/awss3.py
@@ -89,11 +89,11 @@ class S3Storage(FileStorage):
 
     All the files are stored inside a bucket named ``bucket`` on ``host`` which Depot
     connects to using ``access_key_id`` and ``secret_access_key``.
- 
+
     Additional options include:
         * ``host`` which can be used to specify an host different from Amazon
           AWS S3 Storage
-        * ``policy`` which can be used to specify a canned ACL policy of either 
+        * ``policy`` which can be used to specify a canned ACL policy of either
           ``private`` or ``public-read``.
         * ``encrypt_key`` which can be specified to use the server side
           encryption feature.
@@ -164,9 +164,9 @@ class S3Storage(FileStorage):
             key.set_contents_from_string(content, policy=self._policy,
                                          encrypt_key=self._encrypt_key)
 
-    def create(self, content, filename=None, content_type=None):
+    def create(self, content, filename=None, content_type=None, fileid=None):
         content, filename, content_type = self.fileinfo(content, filename, content_type)
-        new_file_id = str(uuid.uuid1())
+        new_file_id = fileid if fileid is not None else str(uuid.uuid1())
         key = self._bucket_driver.new_key(new_file_id)
         self.__save_file(key, content, filename, content_type)
         return new_file_id

--- a/depot/io/boto3.py
+++ b/depot/io/boto3.py
@@ -111,7 +111,7 @@ class S3Storage(FileStorage):
 
     All the files are stored inside a bucket named ``bucket`` on ``host`` which Depot
     connects to using ``access_key_id`` and ``secret_access_key``.
- 
+
     Additional options include:
         * ``region`` which can be used to specify the AWS region.
         * ``endpoint_url`` which can be used to specify an host different from Amazon
@@ -119,7 +119,7 @@ class S3Storage(FileStorage):
         * ``policy`` which can be used to specify a canned ACL policy of either
           ``private`` or ``public-read``.
         * ``storage_class`` which can be used to specify a class of storage.
-        * ``prefix`` parameter can be used to store all files under 
+        * ``prefix`` parameter can be used to store all files under
           specified prefix. Use a prefix like **dirname/** (*see trailing slash*)
           to store in a subdirectory.
     """
@@ -189,9 +189,9 @@ class S3Storage(FileStorage):
                 raise TypeError('Only bytes can be stored, not unicode')
             key.put(Body=content, **attrs)
 
-    def create(self, content, filename=None, content_type=None):
+    def create(self, content, filename=None, content_type=None, fileid=None):
         content, filename, content_type = self.fileinfo(content, filename, content_type)
-        new_file_id = str(uuid.uuid1())
+        new_file_id = fileid if fileid is not None else str(uuid.uuid1())
         key = self._bucket_driver.new_key(new_file_id)
         self.__save_file(key, content, filename, content_type)
         return new_file_id

--- a/depot/io/gridfs.py
+++ b/depot/io/gridfs.py
@@ -73,12 +73,18 @@ class GridFSStorage(FileStorage):
 
         return GridFSStoredFile(fileid, gridout)
 
-    def create(self, content, filename=None, content_type=None):
+    def create(self, content, filename=None, content_type=None, fileid=None):
         content, filename, content_type = self.fileinfo(content, filename, content_type)
-        new_file_id = self._gridfs.put(content,
-                                       filename=filename,
-                                       content_type=content_type,
-                                       last_modified=utils.timestamp())
+        if fileid is None:
+            new_file_id = self._gridfs.put(content,
+                                           filename=filename,
+                                           content_type=content_type,
+                                           last_modified=utils.timestamp())
+        else:
+            new_file_id = self._gridfs.put(content, _id=fileid,
+                                           filename=filename,
+                                           content_type=content_type,
+                                           last_modified=utils.timestamp())
         return str(new_file_id)
 
     def replace(self, file_or_id, content, filename=None, content_type=None):

--- a/depot/io/interfaces.py
+++ b/depot/io/interfaces.py
@@ -152,12 +152,14 @@ class FileStorage(with_metaclass(ABCMeta, object)):
         return
 
     @abstractmethod
-    def create(self, content, filename=None, content_type=None):  # pragma: no cover
+    def create(self, content, filename=None, content_type=None, fileid=None):  # pragma: no cover
         """Saves a new file and returns the ID of the newly created file.
 
         ``content`` parameter can either be ``bytes``, another ``file object``
         or a :class:`cgi.FieldStorage`. When ``filename`` and ``content_type``
         parameters are not provided they are deducted from the content itself.
+        When ``fileid`` is provided it will manually set the file ID used.
+        USE WITH CARE.
         """
         return
 

--- a/depot/io/local.py
+++ b/depot/io/local.py
@@ -105,8 +105,8 @@ class LocalFileStorage(FileStorage):
         with open(_metadata_path(local_file_path), 'w') as metadatafile:
             metadatafile.write(json.dumps(metadata))
 
-    def create(self, content, filename=None, content_type=None):
-        new_file_id = str(uuid.uuid1())
+    def create(self, content, filename=None, content_type=None, fileid=None):
+        new_file_id = fileid if fileid is not None else str(uuid.uuid1())
         content, filename, content_type = self.fileinfo(content, filename, content_type)
         self.__save_file(new_file_id, content, filename, content_type)
         return new_file_id

--- a/depot/io/memory.py
+++ b/depot/io/memory.py
@@ -75,8 +75,8 @@ class MemoryFileStorage(FileStorage):
             }
         }
 
-    def create(self, content, filename=None, content_type=None):
-        new_file_id = str(uuid.uuid1())
+    def create(self, content, filename=None, content_type=None, fileid=None):
+        new_file_id = fileid if fileid is not None else str(uuid.uuid1())
         content, filename, content_type = self.fileinfo(content, filename, content_type)
         self.__save_file(new_file_id, content, filename, content_type)
         return new_file_id

--- a/tests/test_storage_interface.py
+++ b/tests/test_storage_interface.py
@@ -141,6 +141,15 @@ class BaseStorageTestFixture(object):
 
         self.fs.replace(file_id, FILE_CONTENT)
 
+    @raises(IOError)
+    def test_create_set_id(self):
+        file_id = self.fs.create(FILE_CONTENT, 'file.txt')
+        assert self.fs.exists(file_id)
+        self.fs.delete(file_id)
+        assert not self.fs.exists(file_id)
+
+        self.fs.create(FILE_CONTENT, fileid=file_id)
+
     @raises(ValueError)
     def test_replace_invalidid(self):
         self.fs.replace('INVALIDID', FILE_CONTENT)


### PR DESCRIPTION
Use with care, especially with MongoDB. This is probably going to be a controversial PR, but I wanted to put it out there. It should be 100% backwards compatible.