### PR TITLE
feat(sqlalchemy): set cache_ok to False

### DIFF
--- a/depot/fields/sqlalchemy.py
+++ b/depot/fields/sqlalchemy.py
@@ -32,6 +32,7 @@ class UploadedFileField(types.TypeDecorator):
 
     """
     impl = types.Unicode
+    cache_ok = False
 
     def __init__(self, filters=tuple(), upload_type=UploadedFile, upload_storage=None, *args, **kw):
         super(UploadedFileField, self).__init__(*args, **kw)


### PR DESCRIPTION
SQLAlchemy raises the following warnings when using the UploadedFileField:

> SAWarning: TypeDecorator UploadedFileField() will not produce a cache key because the ``cache_ok`` attribute is not set to True.  This can have significant performance implications including some performance degradations in comparison to prior SQLAlchemy versions.  Set this attribute to True if this type object's state is safe to use in a cache key, or False to disable this warning. (Background on this error at: [https://sqlalche.me/e/14/cprf](https://sqlalche.me/e/14/cprf))

As I understand from the [documentation](https://docs.sqlalchemy.org/en/14/core/custom_types.html#sqlalchemy.types.TypeDecorator.cache_ok), UploadedFileField cannot be cached because it accepts non-hashables variables in its init (filters can be a list). 
So I set the flag to False, which does not change the current behavior, just makes the situation explicit.