### PR TITLE
Add support for Pillow 10

### DIFF
--- a/depot/fields/filters/thumbnails.py
+++ b/depot/fields/filters/thumbnails.py
@@ -1,7 +1,7 @@
 from depot.io import utils
 from depot.manager import DepotManager
 from ..interfaces import FileFilter
-from PIL import Image
+from depot._pillow_compat import Image
 from io import BytesIO
 
 
@@ -34,7 +34,7 @@ class WithThumbnailFilter(FileFilter):
         content = utils.file_from_content(uploaded_file.original_content)
 
         thumbnail = Image.open(content)
-        thumbnail.thumbnail(self.thumbnail_size, Image.BILINEAR)
+        thumbnail.thumbnail(self.thumbnail_size, Image.Resampling.BILINEAR)
         thumbnail = thumbnail.convert('RGBA')
         thumbnail.format = self.thumbnail_format
 

--- a/depot/fields/specialized/image.py
+++ b/depot/fields/specialized/image.py
@@ -2,7 +2,7 @@ from depot.io import utils
 from depot.manager import DepotManager
 from ..upload import UploadedFile
 from depot.io.interfaces import FileStorage
-from PIL import Image
+from depot._pillow_compat import Image
 from depot.io.utils import INMEMORY_FILESIZE
 from tempfile import SpooledTemporaryFile
 
@@ -34,7 +34,7 @@ class UploadedImageWithThumb(UploadedFile):
 
         uploaded_image = Image.open(content)
         if max(uploaded_image.size) >= self.max_size:
-            uploaded_image.thumbnail((self.max_size, self.max_size), Image.BILINEAR)
+            uploaded_image.thumbnail((self.max_size, self.max_size), Image.Resampling.BILINEAR)
             content = SpooledTemporaryFile(INMEMORY_FILESIZE)
             uploaded_image.save(content, uploaded_image.format)
 
@@ -42,7 +42,7 @@ class UploadedImageWithThumb(UploadedFile):
         super(UploadedImageWithThumb, self).process_content(content, filename, content_type)
 
         thumbnail = uploaded_image.copy()
-        thumbnail.thumbnail(self.thumbnail_size, Image.ANTIALIAS)
+        thumbnail.thumbnail(self.thumbnail_size, Image.Resampling.LANCZOS)
         thumbnail = thumbnail.convert('RGBA')
         thumbnail.format = self.thumbnail_format
 

--- a/docs/database.rst
+++ b/docs/database.rst
@@ -132,7 +132,7 @@ A filter that creates a thumbnail for an image would look like::
             content = utils.file_from_content(uploaded_file.original_content)
 
             thumbnail = Image.open(content)
-            thumbnail.thumbnail(self.thumbnail_size, Image.BILINEAR)
+            thumbnail.thumbnail(self.thumbnail_size, Image.Resampling.BILINEAR)
             thumbnail = thumbnail.convert('RGBA')
             thumbnail.format = self.thumbnail_format
 
@@ -213,7 +213,7 @@ a maximum resolution::
             uploaded_image = Image.open(content)
             if max(uploaded_image.size) >= self.max_size:
                 uploaded_image.thumbnail((self.max_size, self.max_size),
-                                         Image.BILINEAR)
+                                         Image.Resampling.BILINEAR)
                 content = SpooledTemporaryFile(INMEMORY_FILESIZE)
                 uploaded_image.save(content, uploaded_image.format)
 

--- a/tests/test_fields_ming.py
+++ b/tests/test_fields_ming.py
@@ -2,7 +2,7 @@
 import shutil
 import unittest
 import tempfile, os, cgi, base64
-from PIL import Image
+from depot._pillow_compat import Image
 from depot.fields.filters.thumbnails import WithThumbnailFilter
 from depot.fields.ming import UploadedFileProperty
 from depot.manager import DepotManager, get_file

--- a/tests/test_fields_sqlalchemy.py
+++ b/tests/test_fields_sqlalchemy.py
@@ -2,7 +2,7 @@
 import shutil
 import unittest
 import tempfile, os, cgi, base64
-from PIL import Image
+from depot._pillow_compat import Image
 from sqlalchemy.exc import StatementError
 from sqlalchemy.orm import relationship
 from sqlalchemy.schema import Column, ForeignKey


### PR DESCRIPTION
Image.ANTIALIAS was replaced by Image.Resampling.LANCZOS. However, the Resampling class is not available in Pillow < 9.1.0, so we need to stub it. Since we would like to support Python 2, it cannot be an IntEnum.

Note: I wasn't able to set up Python 2 on my system to test.

Resolves #75.