### PR TITLE
Update manager.py

### DIFF
--- a/depot/manager.py
+++ b/depot/manager.py
@@ -32,7 +32,7 @@ class DepotManager(object):
     def get_default(cls):
         """Retrieves the current application default depot"""
         if cls._default_depot is None:
-            raise RuntimeError('Not depots have been configured!')
+            raise RuntimeError('No depots have been configured!')
         return cls._default_depot
 
     @classmethod


### PR DESCRIPTION
Fix spelling: 'Not depots have been configured!' -> 'No depots have been configured!'